### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,5 @@
     "gulp-useref": "^3.0.4",
     "run-sequence": "^1.1.2"
   },
-  "dependencies": {
-    "npm": "^6.4.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION

Hello slaus!

It seems like you have npm as one of your (dev-) dependency in kohas.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
